### PR TITLE
Allow multi CIDR in whitelist

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -15,8 +15,7 @@
     ratelimit * /week 100 200 week
 
     ratelimit get 1 2 minute {
-        whitelist 127.0.0.1/32
-        whitelist 10.10.2.15/32
+        whitelist 127.0.0.1/32,10.10.2.15/32
         status 404
         /404
     }

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ ratelimit methods rate burst unit {
 ```
 
 - `whitelist` is the keyword for whitelist your trusted ips (comma separately). [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) is the IP range you don't want to perform `rate limit`. `whitelist` is a general rule, it won't target for specific resource.
-- `status` is the keyword for matching the response status code (comma separately).
+- `status` is the keyword for matching the [response status code](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes) (comma separately).
 If this rule is triggered, all subsequent requests from that client will be blocked regardless of which status code is returned or which resource is requested.
 **Note:** this won't block resources not defined in `ratelimit`'s config.
 - `resources` is a list of files/directories to apply `rate limit`, one per line

--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ For multiple resources:
 
 ```
 ratelimit methods rate burst unit {
-    whitelist CIDR
-    status 403,503
+    whitelist CIDR,CIDR
+    status xxx,xxx
     resources
 }
 ```
 
-- `whitelist` is the keyword for whitelist your trusted ips, [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) is the IP range you don't want to perform `rate limit`. `whitelist` is a general rule, it won't target for specific resource.
+- `whitelist` is the keyword for whitelist your trusted ips (comma separately). [CIDR](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing) is the IP range you don't want to perform `rate limit`. `whitelist` is a general rule, it won't target for specific resource.
 - `status` is the keyword for matching the response status code (comma separately).
 If this rule is triggered, all subsequent requests from that client will be blocked regardless of which status code is returned or which resource is requested.
 **Note:** this won't block resources not defined in `ratelimit`'s config.
@@ -56,8 +56,7 @@ Don't perform `rate limit` if requests come from **1.2.3.4** or **192.168.1.0/30
 
 ```
 ratelimit get,post 2 2 minute {
-    whitelist 1.2.3.4/32
-    whitelist 192.168.1.0/30
+    whitelist 1.2.3.4/32,192.168.1.0/30
     status *
     /foo.html
     /api

--- a/setup.go
+++ b/setup.go
@@ -106,7 +106,7 @@ func rateLimitParse(c *caddy.Controller) (rules []Rule, err error) {
 					// TODO: check status code is valid
 					rule.Status = args[0]
 				} else {
-					return rules, c.Errf("expecting whitelist, got %s", val)
+					return rules, c.Errf("expecting whitelist or status, got %s", val)
 				}
 			default:
 				return rules, c.ArgErr()

--- a/setup.go
+++ b/setup.go
@@ -3,6 +3,7 @@ package ratelimit
 import (
 	"net"
 	"strconv"
+	"strings"
 
 	"github.com/mholt/caddy"
 	"github.com/mholt/caddy/caddyhttp/httpserver"
@@ -94,11 +95,13 @@ func rateLimitParse(c *caddy.Controller) (rules []Rule, err error) {
 			case 1:
 				if "whitelist" == val {
 					// check if CIDR is valid
-					_, _, err := net.ParseCIDR(args[0])
-					if err != nil {
-						return rules, err
+					for _, v := range strings.Split(args[0], ",") {
+						_, _, err := net.ParseCIDR(v)
+						if err != nil {
+							return rules, err
+						}
+						rule.Whitelist = append(rule.Whitelist, v)
 					}
-					rule.Whitelist = append(rule.Whitelist, args[0])
 				} else if "status" == val {
 					// TODO: check status code is valid
 					rule.Status = args[0]


### PR DESCRIPTION
This PR allows users to add multi CIDRs with one line config, it would also make config file looks cleaner.